### PR TITLE
Fix line 104 and replace interaction dpkg-reconfigure ca-certificates

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -101,8 +101,11 @@ sudo echo "SELECTED_EDITOR=\"/bin/nano\"" >> /$USER/.selected_editor
 # enter to navigate the CA Certificates menu:
 echo "<USER> is $USER"
 echo "<FQDN> is $FQDN"
-sudo cp /$USER/.acme.sh/$FQDN/ca.cer /usr/share/ca-certificates/ca.crt
-sudo dpkg-reconfigure ca-certificates
+sudo cp /home/$USER/.acme.sh/$FQDN/ca.cer /usr/share/ca-certificates/ca.crt
+sudo su
+echo 'ca.crt' >> /etc/ca-certificates.conf
+update-ca-certificates
+exit
 
 # Stop the zen application and configure the certificate location, then start zend again:
 pkill -f zend


### PR DESCRIPTION
1. line 104 is missing /home
2. can get rid of interactive panel from dpkg-reconfigure ca-certificates by inserting the crt name (with no ! in front of it) into /etc/ca-certificates.conf and running update-ca-certificates which has no interaction